### PR TITLE
genai-function-calling: jq safe example and fix spring config

### DIFF
--- a/genai-function-calling/README.md
+++ b/genai-function-calling/README.md
@@ -26,7 +26,7 @@ performs the same process. The user asks a question that is beyond the training
 date of the LLM. The application uses the framework to implement an agent
 pattern to automatically call functions when it needs new information.
 
-Here's how the question "What's the latest version of Elasticsearch 8?" ends up
+Here's how the question "What is the latest version of Elasticsearch 8?" ends up
 being answered.
 
 ```mermaid
@@ -35,7 +35,7 @@ sequenceDiagram
     participant LLM
 
     Note over Agent: Framework sends its tools along with the prompt
-    Agent ->> LLM: user: "What's the latest version of Elasticsearch 8?"
+    Agent ->> LLM: user: "What is the latest version of Elasticsearch 8?"
     activate LLM
     Note over LLM: LLM determines it needs to use a tool to complete the task
 

--- a/genai-function-calling/semantic-kernel-dotnet/Program.cs
+++ b/genai-function-calling/semantic-kernel-dotnet/Program.cs
@@ -94,7 +94,7 @@ class Program
 
 
         var chatHistory = new ChatHistory();
-        chatHistory.AddUserMessage("What's the latest version of Elasticsearch 8?");
+        chatHistory.AddUserMessage("What is the latest version of Elasticsearch 8?");
 
         await foreach (ChatMessageContent response in agent.InvokeAsync(chatHistory))
         {

--- a/genai-function-calling/spring-ai/env.example
+++ b/genai-function-calling/spring-ai/env.example
@@ -1,8 +1,10 @@
 # Update this with your real OpenAI API key
 OPENAI_API_KEY=
 
-# Uncomment to use Ollama instead of OpenAI
-# OPENAI_BASE_URL=http://localhost:11434/v1
+# Uncomment to use Ollama instead of OpenAI.
+# Note: OpenAI's OPENAI_BASE_URL var ends in /v1, while this doesn't, until:
+# https://github.com/spring-projects/spring-ai/issues/2415
+# OPENAI_BASE_URL=http://localhost:11434
 # OPENAI_API_KEY=unused
 # CHAT_MODEL=qwen2.5:3b
 

--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -46,7 +46,7 @@ const getLatestElasticsearchVersion = tool({
 async function main() {
     const {text} = await generateText({
         model: openai(model),
-        messages: [{role: 'user', content: "What's the latest version of Elasticsearch 8?"}],
+        messages: [{role: 'user', content: "What is the latest version of Elasticsearch 8?"}],
         temperature: 0,
         tools: {
             getLatestElasticsearchVersion: getLatestElasticsearchVersion,


### PR DESCRIPTION
by replacing `what's` with `what is`, if you proxy requests to see the raw output (e.g. ` socat -v TCP-LISTEN:8080,fork TCP:localhost:8081`), you can reformat json in your favorite way without worry.

Also, I noticed the example env for spring was off and raised an issue upstream on it.