### PR TITLE
genai-function-calling: updates deps and adds podman/ramalama instructions

### DIFF
--- a/genai-function-calling/README.md
+++ b/genai-function-calling/README.md
@@ -78,5 +78,27 @@ http://localhost:5601/app/apm/traces?rangeFrom=now-15m&rangeTo=now
 
 ![Kibana screenshot](./kibana-trace.png)
 
+## Prerequisites
+
+Docker or Podman is required. You'll also need an OpenAI API compatible
+inference platform and an OpenTelemetry collector.
+
+First of all, you need to be in a directory that contains this repository. If
+you haven't yet, you get one like this:
+```bash
+curl -L https://github.com/elastic/observability-examples/archive/refs/heads/main.tar.gz | tar -xz
+cd observability-examples-main/genai-function-calling/
+```
+
+### Podman
+
+If you are using [Podman](https://podman.io/) to run docker containers, export
+`HOST_IP`. If you don't you'll get this error running exercises:
+> unable to upgrade to tcp, received 500
+
+Here's how to export your `HOST_IP`:
+  * If macOS: `export HOST_IP=$(ipconfig getifaddr en0)`
+  * If Ubuntu: `export HOST_IP=$(hostname -I | awk '{print $1}')`
+
 ---
 [native]: https://opentelemetry.io/docs/languages/java/instrumentation/#native-instrumentation

--- a/genai-function-calling/openai-agents/Dockerfile
+++ b/genai-function-calling/openai-agents/Dockerfile
@@ -1,12 +1,6 @@
 # Use glibc-based image with pre-compiled wheels for psutil
 FROM python:3.12-slim
 
-# TODO: temporary until openai-agents 0.0.5
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN --mount=type=cache,target=/root/.cache/pip python -m pip install --upgrade pip
 
 COPY requirements.txt /tmp
@@ -15,4 +9,4 @@ RUN --mount=type=cache,target=/root/.cache/pip edot-bootstrap --action=install
 
 COPY main.py /
 
-CMD [ "python", "main.py" ]
+CMD [ "opentelemetry-instrument", "python", "main.py" ]

--- a/genai-function-calling/openai-agents/docker-compose.yml
+++ b/genai-function-calling/openai-agents/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"

--- a/genai-function-calling/openai-agents/env.example
+++ b/genai-function-calling/openai-agents/env.example
@@ -8,6 +8,13 @@ OPENAI_API_KEY=
 # # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
 # CHAT_MODEL=qwen2.5:0.5b
 
+# Uncomment to use RamaLama instead of OpenAI
+# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_KEY=unused
+# # This works when you supply a major_version parameter in your prompt. If you
+# # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
+# CHAT_MODEL=qwen2.5:0.5b
+
 # Uncomment and complete if you want to use Azure OpenAI Service
 ## "Azure OpenAI Endpoint" in https://oai.azure.com/resource/overview
 # AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/

--- a/genai-function-calling/openai-agents/requirements.txt
+++ b/genai-function-calling/openai-agents/requirements.txt
@@ -1,5 +1,4 @@
-# TODO: temporary until openai-agents 0.0.5
-openai-agents @ git+https://github.com/openai/openai-agents-python.git@main
+openai-agents~=0.0.5
 httpx~=0.28.1
 
 elastic-opentelemetry~=0.8.0

--- a/genai-function-calling/semantic-kernel-dotnet/Dockerfile
+++ b/genai-function-calling/semantic-kernel-dotnet/Dockerfile
@@ -1,7 +1,7 @@
 ARG DOTNET_VERSION=9.0
 
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-alpine AS edot
-ARG EDOT_VERSION=1.0.0-beta.1
+ARG EDOT_VERSION=1.0.0-beta.2
 ARG EDOT_INSTALL=https://github.com/elastic/elastic-otel-dotnet/releases/download/${EDOT_VERSION}/elastic-dotnet-auto-install.sh
 ENV OTEL_DOTNET_AUTO_HOME=/edot
 WORKDIR /edot

--- a/genai-function-calling/semantic-kernel-dotnet/app.csproj
+++ b/genai-function-calling/semantic-kernel-dotnet/app.csproj
@@ -11,9 +11,9 @@
  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.40.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.40.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.40.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.42.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.42.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.42.0" />
   </ItemGroup>
 
 </Project>

--- a/genai-function-calling/semantic-kernel-dotnet/docker-compose.yml
+++ b/genai-function-calling/semantic-kernel-dotnet/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"

--- a/genai-function-calling/semantic-kernel-dotnet/env.example
+++ b/genai-function-calling/semantic-kernel-dotnet/env.example
@@ -8,6 +8,13 @@ OPENAI_API_KEY=
 # # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
 # CHAT_MODEL=qwen2.5:0.5b
 
+# Uncomment to use RamaLama instead of OpenAI
+# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_KEY=unused
+# # This works when you supply a major_version parameter in your prompt. If you
+# # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
+# CHAT_MODEL=qwen2.5:0.5b
+
 # Uncomment and complete if you want to use Azure OpenAI Service
 ## "Azure OpenAI Endpoint" in https://oai.azure.com/resource/overview
 # AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/

--- a/genai-function-calling/spring-ai/.mvn/wrapper/maven-wrapper.properties
+++ b/genai-function-calling/spring-ai/.mvn/wrapper/maven-wrapper.properties
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   https://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/genai-function-calling/spring-ai/docker-compose.yml
+++ b/genai-function-calling/spring-ai/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"

--- a/genai-function-calling/spring-ai/env.example
+++ b/genai-function-calling/spring-ai/env.example
@@ -8,6 +8,13 @@ OPENAI_API_KEY=
 # # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
 # CHAT_MODEL=qwen2.5:0.5b
 
+# Uncomment to use RamaLama instead of OpenAI
+# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_KEY=unused
+# # This works when you supply a major_version parameter in your prompt. If you
+# # leave it out, you need to update this to qwen2.5:3b to proceed the tool call.
+# CHAT_MODEL=qwen2.5:0.5b
+
 # Uncomment and complete if you want to use Azure OpenAI Service
 ## "Azure OpenAI Endpoint" in https://oai.azure.com/resource/overview
 # AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/

--- a/genai-function-calling/spring-ai/mvnw
+++ b/genai-function-calling/spring-ai/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    https://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/genai-function-calling/spring-ai/mvnw.cmd
+++ b/genai-function-calling/spring-ai/mvnw.cmd
@@ -8,7 +8,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    https://www.apache.org/licenses/LICENSE-2.0
+@REM    http://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>co.elastic.otel</groupId>
             <artifactId>elastic-otel-javaagent</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
             <scope>optional</scope>
         </dependency>
     </dependencies>

--- a/genai-function-calling/vercel-ai/docker-compose.yml
+++ b/genai-function-calling/vercel-ai/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     extra_hosts:  # send localhost traffic to the docker host, e.g. your laptop
-      - "localhost:host-gateway"
+      - "localhost:${HOST_IP:-host-gateway}"

--- a/genai-function-calling/vercel-ai/env.example
+++ b/genai-function-calling/vercel-ai/env.example
@@ -7,6 +7,12 @@ OPENAI_API_KEY=
 # # This needs qwen2.5:3b, as qwen2.5:0.5b doesn't process the tool call
 # CHAT_MODEL=qwen2.5:3b
 
+# Uncomment to use RamaLama instead of OpenAI
+# OPENAI_BASE_URL=http://localhost:8080/v1
+# OPENAI_API_KEY=unused
+# # This needs qwen2.5:3b, as qwen2.5:0.5b doesn't process the tool call
+# CHAT_MODEL=qwen2.5:3b
+
 # Uncomment and complete if you want to use Azure OpenAI Service
 ## "Azure OpenAI Endpoint" in https://oai.azure.com/resource/overview
 # AZURE_OPENAI_ENDPOINT=https://YOUR_RESOURCE_NAME.openai.azure.com/

--- a/genai-function-calling/vercel-ai/package.json
+++ b/genai-function-calling/vercel-ai/package.json
@@ -4,15 +4,15 @@
   "private": true,
   "type": "commonjs",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "start": "node --env-file .env -r @elastic/opentelemetry-node index.js"
   },
   "dependencies": {
-    "ai": "^4.1.46",
-    "@ai-sdk/azure": "^1.2.1",
-    "@ai-sdk/openai": "^1.1.15",
+    "ai": "^4.1.63",
+    "@ai-sdk/azure": "^1.2.6",
+    "@ai-sdk/openai": "^1.2.6",
     "@elastic/opentelemetry-node": "*"
   },
   "_comment": "Override to avoid punycode warnings in recent versions of Node.JS",


### PR DESCRIPTION
This adds the same instructions from https://github.com/elastic/testing-genai-applications so that podman and ramalama work. This also updates openai agents as we no longer need a temporary version, and the others while I was at it.

<img width="1291" alt="Screenshot 2025-03-20 at 12 24 40 PM" src="https://github.com/user-attachments/assets/d1c2b2a8-88ce-448d-880d-6d868e1776d6" />
