### PR TITLE
genai-function-calling: Adds MCP example to vercel-ai

### DIFF
--- a/genai-function-calling/vercel-ai/Dockerfile
+++ b/genai-function-calling/vercel-ai/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-alpine
 
 WORKDIR /app
-COPY package.json index.js /app/
+COPY package.json *.js /app/
 RUN touch .env && npm install
 
-CMD ["npm", "start"]
+ENTRYPOINT ["npm", "start"]

--- a/genai-function-calling/vercel-ai/README.md
+++ b/genai-function-calling/vercel-ai/README.md
@@ -33,6 +33,23 @@ npm install
 npm start
 ```
 
+
+## Run with Model Context Protocol (MCP)
+
+[mcp.js](mcp.js) includes code needed to decouple tool discovery and invocation
+via the [Model Context Protocol (MCP) flow][flow-mcp]. To run using MCP, append
+`-- --mcp` flag to `npm start` or `docker compose run` command.
+
+For example, to run with Docker:
+```bash
+npm run start -- --mcp
+```
+
+Or to run with npm:
+```bash
+npm run start -- --mcp
+```
+
 ## Notes
 
 The LLM should generate something like "The latest stable version of
@@ -45,4 +62,4 @@ metrics).
 ---
 [flow]: ../README.md#example-application-flow
 [vercel-ai]: https://github.com/vercel/ai
-
+[flow-mcp]: ../README.md#model-context-protocol-flow

--- a/genai-function-calling/vercel-ai/README.md
+++ b/genai-function-calling/vercel-ai/README.md
@@ -42,7 +42,7 @@ via the [Model Context Protocol (MCP) flow][flow-mcp]. To run using MCP, append
 
 For example, to run with Docker:
 ```bash
-npm run start -- --mcp
+docker compose run --build --rm genai-function-calling -- --mcp
 ```
 
 Or to run with npm:

--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -1,6 +1,6 @@
 const {createAzure} = require('@ai-sdk/azure');
 const {createOpenAI} = require('@ai-sdk/openai');
-const {generateText, tool, ToolSet} = require('ai');
+const {generateText, tool} = require('ai');
 const {z} = require('zod');
 const {mcpClientMain} = require('./mcp');
 
@@ -48,9 +48,9 @@ const tools = {get_latest_elasticsearch_version: getLatestElasticsearchVersion};
 /**
  * Runs the agent with the given tools.
  *
- * @param {ToolSet} tools - The tools the LLM can use to answer the question.
+ * @param {import('ai').ToolSet} tools - The tools the LLM can use to answer the question.
  */
-async function runAgent(tools = tools) {
+async function runAgent(tools) {
     const {text} = await generateText({
         model: openai(model),
         messages: [{role: 'user', content: "What is the latest version of Elasticsearch 8?"}],

--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -1,7 +1,8 @@
 const {createAzure} = require('@ai-sdk/azure');
-const {createOpenAI} = require('@ai-sdk/openai')
-const {generateText, tool} = require('ai');
+const {createOpenAI} = require('@ai-sdk/openai');
+const {generateText, tool, ToolSet} = require('ai');
 const {z} = require('zod');
+const {mcpClientMain} = require('./mcp');
 
 const openai = process.env.AZURE_OPENAI_API_KEY
     ? createAzure({ // coerce to standard OpenAI SDK ENV variables
@@ -19,7 +20,7 @@ const getLatestElasticsearchVersion = tool({
     parameters: z.object({
         majorVersion: z.number().optional().describe('Major version to filter by (e.g. 7, 8). Defaults to latest'),
     }),
-    execute: async ({ majorVersion }) => {
+    execute: async ({majorVersion}) => {
         const response = await fetch('https://artifacts.elastic.co/releases/stack.json');
         const data = await response.json();
         const latest = data.releases
@@ -33,7 +34,7 @@ const getLatestElasticsearchVersion = tool({
             })
             .map(release => release.version.replace(' GA', ''))
             // "8.9.1" > "8.10.0", unless configured to handle *numeric* segments
-            .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+            .sort((a, b) => a.localeCompare(b, undefined, {numeric: true}))
             .pop();
         if (!latest) {
             throw new Error('No stable versions found');
@@ -42,20 +43,35 @@ const getLatestElasticsearchVersion = tool({
     },
 });
 
-async function main() {
+const tools = {get_latest_elasticsearch_version: getLatestElasticsearchVersion};
+
+/**
+ * Runs the agent with the given tools.
+ *
+ * @param {ToolSet} tools - The tools the LLM can use to answer the question.
+ */
+async function runAgent(tools = tools) {
     const {text} = await generateText({
         model: openai(model),
         messages: [{role: 'user', content: "What is the latest version of Elasticsearch 8?"}],
         temperature: 0,
-        tools: {
-            getLatestElasticsearchVersion: getLatestElasticsearchVersion,
-        },
+        tools,
         tool_choice: 'auto',
         maxSteps: 10,
-        experimental_telemetry: { isEnabled: true },
+        experimental_telemetry: {isEnabled: true},
     });
 
     console.log(text);
 }
 
-main();
+async function main() {
+    if (process.argv.some(arg => arg.startsWith("--mcp"))) {
+        return await mcpClientMain(runAgent, tools);
+    }
+    await runAgent(tools);
+}
+
+main().catch(error => {
+    console.error('Error:', error);
+    process.exit(1);
+});

--- a/genai-function-calling/vercel-ai/mcp.js
+++ b/genai-function-calling/vercel-ai/mcp.js
@@ -1,0 +1,97 @@
+const {McpServer} = require('@modelcontextprotocol/sdk/server/mcp.js');
+const {StdioServerTransport} = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {StdioClientTransport} = require('@modelcontextprotocol/sdk/client/stdio.js');
+const {experimental_createMCPClient} = require('ai');
+
+const fs = require('fs');
+const path = require('path');
+
+const SERVER_ARG = '--mcp-server';
+
+// Get MCP server parameters from package.json
+let name, version;
+try {
+    const packageJsonPath = path.join(__dirname, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    name = packageJson.name;
+    version = packageJson.version;
+} catch (error) {
+    console.error('Failed to read package.json:', error.message);
+    process.exit(1);
+}
+
+/**
+ * Starts an MCP server and registers the provided tools, listening on stdin/stdout.
+ *
+ * @param {import('ai').ToolSet} tools - The tools to register with the MCP server.
+ */
+async function mcpServerMain(tools) {
+    const server = new McpServer({name, version});
+
+    // Register each tool with the server
+    Object.entries(tools).forEach(([toolName, tool]) => {
+        console.log(`Registering tool: ${toolName}`);
+        server.tool(
+            toolName,
+            tool.description,
+            tool.parameters.shape,
+            async (params) => {
+                try {
+                    const result = await tool.execute(params);
+                    return {content: [{type: 'text', text: result}]};
+                } catch (error) {
+                    return {content: [{type: 'text', text: error.message}]};
+                }
+            }
+        );
+    });
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+
+/**
+ * Launches an MCP server in a subprocess and runs the agent with its tools via a client.
+ *
+ * @param {Function} runAgent - The function to run the agent with the retrieved tools.
+ */
+async function runAgentWithMCPClient(runAgent) {
+    // MCP server is a subprocess, which doesn't inherit anything by default.
+    // Minimally, we need to pass an argument to let the process know it is
+    // running as a server. We also propagate any ENV or arguments to ensure
+    // OpenTelemetry auto-instrumentation propagates to the child, such as
+    // '-r @elastic/opentelemetry-node'. Don't do this with untrusted servers.
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [...process.execArgv, ...process.argv.slice(1), SERVER_ARG],
+        env: process.env,
+    });
+
+    let client;
+    try {
+        client = await experimental_createMCPClient({transport});
+        const tools = await client.tools();
+        await runAgent(tools);
+    } catch (error) {
+        throw error;
+    } finally {
+        await client?.close();  // closing the client closes its transport
+    }
+}
+
+/**
+ * Main entry point to either run the MCP server directly or launch it in a subprocess
+ * and run the agent with as an MCP client.
+ *
+ * @param {Function} runAgent - The function to run the agent with the tools.
+ * @param {import('ai').ToolSet} tools - The tools to register with the MCP server.
+ */
+async function mcpClientMain(runAgent, tools) {
+    if (process.argv.includes(SERVER_ARG)) {
+        await mcpServerMain(tools);
+    } else {
+        await runAgentWithMCPClient(runAgent);
+    }
+}
+
+module.exports = {mcpClientMain};

--- a/genai-function-calling/vercel-ai/package.json
+++ b/genai-function-calling/vercel-ai/package.json
@@ -10,9 +10,10 @@
     "start": "node --env-file .env -r @elastic/opentelemetry-node index.js"
   },
   "dependencies": {
-    "ai": "^4.3.2",
     "@ai-sdk/azure": "^1.3.8",
     "@ai-sdk/openai": "^1.3.7",
-    "@elastic/opentelemetry-node": "^1"
+    "@elastic/opentelemetry-node": "^1",
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "ai": "^4.3.2"
   }
 }


### PR DESCRIPTION
This adds a Model Context Protocol ([MCP][mcp]) variant of the genai-function-calling example, for tool discovery and execution. This starts with Vercel AI, and others can follow.

This uses the "stdio" transport which involves launching a subprocess. For convenience, the MCP server is defined in the same project as the normal example. This follows the same convenience pattern as [Goose](https://gist.github.com/codefromthecrypt/8a96493bee2c2b45a513073dc5a6811a) uses for its internal MCP servers.

To run the vercel example is easy, you just append `-- --mcp` like this in Docker

```bash
docker compose run --build --rm genai-function-calling  -- --mcp
```

The main difference is that instead of calling a local function to get the latest version of Elasticsearch, the agent creates and MCP server process and discovers the function via the MCP protocol. When the LLM uses that function, it uses the same protocol to invoke the function. Otherwise, the flow is the same.

Here's a diagram of the MCP variant, which notably augments the original by decoupling tool discovery and execution from the agent, which is now also an MCP client.

```mermaid
sequenceDiagram
    participant Agent as Agent (MCP Client)
    participant MCP as MCP Server (subprocess)
    participant LLM

    participant Agent
    participant LLM

    Note over Agent: Spawns MCP Server subprocess and connects via stdio
    activate MCP
    MCP ->> MCP: Initialize and ready
    deactivate MCP

    Agent ->> MCP: initialize: {clientInfo, protocolVersion}
    activate MCP
    MCP -->> Agent: response: {capabilities, instructions, serverInfo}
    deactivate MCP

    Agent ->> MCP: tools/list
    activate MCP
    MCP -->> Agent: response: {tools: [{name: "get_latest_elasticsearch_version", ...}]}
    deactivate MCP

    Agent ->> LLM: user: "What is the latest version of Elasticsearch 8?"
    activate LLM
    Note over LLM: LLM determines it needs to use a tool to complete the task

    LLM ->> Agent: assistant: {"function": {"name": "get_latest_elasticsearch_version", "arguments": "{\"majorVersion\": 8}"}}
    deactivate LLM
    activate Agent
    Note over Agent: invokes get_latest_elasticsearch_version(majorVersion=8)

    Agent -->> LLM: [user, assistant, tool: "8.17.4"]
    Note over Agent: LLM is stateless, the tool result is sent back with prior messages
    deactivate Agent
    activate LLM

    LLM ->> Agent: content: "The latest version of Elasticsearch 8 is 8.17.4"
    deactivate LLM
    Note over Agent: "The latest version of Elasticsearch 8 is 8.17.4"

    Agent ->> MCP: Close stdin
    activate MCP
    MCP ->> MCP: Exits
    deactivate MCP
```

Note: If you are using OpenTelemetry, there's not yet a way to join traces across the MCP process boundary. This means that the HTTP call to get the latest version of Elasticsearch will be in a separate trace from the agent.

So it looks like this in [otel-tui](https://github.com/ymtdzzz/otel-tui):

<img width="522" alt="Screenshot 2025-04-10 at 10 55 46 AM" src="https://github.com/user-attachments/assets/24c38152-04f1-4f1b-ab08-8908183cbfec" />

<img width="1440" alt="Screenshot 2025-04-10 at 10 56 11 AM" src="https://github.com/user-attachments/assets/a28c54dd-de02-41e4-84ff-96a5bdb03f89" />

<img width="1323" alt="Screenshot 2025-04-10 at 10 55 58 AM" src="https://github.com/user-attachments/assets/48cb9fb3-13fe-4dd4-bcc2-a3d89d047e32" />

Basically, the ai.toolCall span should be a parent of the GET trace, so be in the same trace instead of split across two. Once header (or similar) propagation exists in the MCP specification or a custom protocol, we can fix this up easy.

If you are interested in this aspect, please follow this [discussion][mcp-otel] in the MCP specification for updates.

---
[mcp]: https://modelcontextprotocol.io/specification
[mcp-otel]: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/269
