### PR TITLE
genai-function-calling: update spring-ai to 1.0.0-M7

### DIFF
--- a/genai-function-calling/spring-ai/Dockerfile
+++ b/genai-function-calling/spring-ai/Dockerfile
@@ -2,11 +2,14 @@ FROM eclipse-temurin:21-jdk-alpine AS build
 
 WORKDIR /build
 
-# Copy the local code to the container
-COPY mvnw pom.xml ./
-COPY src ./src
+# Install dependencies (verify resolves more than dependency:go-offline)
+COPY mvnw ./
 COPY .mvn ./.mvn
+COPY pom.xml ./
+RUN ./mvnw verify -DskipTests
 
+# Copy source code and build the application
+COPY src ./src
 RUN ./mvnw package
 
 FROM eclipse-temurin:21-jre-alpine

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -14,8 +14,8 @@
     <name>genai-function-calling</name>
     <description>Function Calling with Spring AI</description>
     <properties>
-        <java.version>17</java.version>
-        <spring-ai.version>1.0.0-M6</spring-ai.version>
+        <java.version>21</java.version>
+        <spring-ai.version>1.0.0-M7</spring-ai.version>
     </properties>
     <dependencies>
         <dependency>
@@ -24,11 +24,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
+            <artifactId>spring-ai-starter-model-azure-openai</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/genai-function-calling/spring-ai/src/main/java/example/Main.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Main.java
@@ -59,15 +59,9 @@ public class Main {
 		String chatModel = azureApiKey != null && !azureApiKey.trim().isEmpty()
 				? SpringAIModels.AZURE_OPENAI
 				: SpringAIModels.OPENAI;
-		// Right now, we cannot select azure or openai with a single property, so set all of them.
-        // See https://github.com/spring-projects/spring-ai/issues/2712
 		new SpringApplicationBuilder(Main.class)
-				.properties(
-						SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL + "=" + chatModel,
-						SpringAIModelProperties.CHAT_MODEL + "=" + chatModel,
-						SpringAIModelProperties.EMBEDDING_MODEL + "=" + chatModel,
-						SpringAIModelProperties.IMAGE_MODEL + "=" + chatModel
-				).run(args);
+				.properties(SpringAIModelProperties.CHAT_MODEL + "=" + chatModel)
+				.run(args);
 	}
 
 }

--- a/genai-function-calling/spring-ai/src/main/java/example/Main.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Main.java
@@ -6,10 +6,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.SpringAIModelProperties;
+import org.springframework.ai.model.SpringAIModels;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -17,12 +19,12 @@ import org.springframework.stereotype.Component;
 public class Main {
 
 	@Component
-    static class VersionAgent implements CommandLineRunner {
+	static class VersionAgent implements CommandLineRunner {
 
 		private final ChatClient chat;
 		private final ElasticsearchTools tools;
 
-        VersionAgent(ChatModel chat, ElasticsearchTools tools) {
+		VersionAgent(ChatModel chat, ElasticsearchTools tools) {
 			this.chat = ChatClient.builder(chat).build();
 			this.tools = tools;
 		}
@@ -51,7 +53,21 @@ public class Main {
 	}
 
 	public static void main(String[] args) {
-		SpringApplication.run(Main.class, args);
+		// Choose between Azure OpenAI and OpenAI based on the presence of the official SDK
+        // environment variable AZURE_OPENAI_API_KEY. Otherwise, we'd create two beans.
+		String azureApiKey = System.getenv("AZURE_OPENAI_API_KEY");
+		String chatModel = azureApiKey != null && !azureApiKey.trim().isEmpty()
+				? SpringAIModels.AZURE_OPENAI
+				: SpringAIModels.OPENAI;
+		// Right now, we cannot select azure or openai with a single property, so set all of them.
+        // See https://github.com/spring-projects/spring-ai/issues/2712
+		new SpringApplicationBuilder(Main.class)
+				.properties(
+						SpringAIModelProperties.AUDIO_TRANSCRIPTION_MODEL + "=" + chatModel,
+						SpringAIModelProperties.CHAT_MODEL + "=" + chatModel,
+						SpringAIModelProperties.EMBEDDING_MODEL + "=" + chatModel,
+						SpringAIModelProperties.IMAGE_MODEL + "=" + chatModel
+				).run(args);
 	}
 
 }

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -33,8 +33,9 @@ logging:
     org:
       springframework:
         ai:
-          autoconfigure:
+          model:
             chat:
               observation:
-                # Hush warnings about prompt and completion logging
-                ChatObservationAutoConfiguration: OFF
+                autoconfigure:
+                  # Hush warnings about prompt and completion logging
+                  ChatObservationAutoConfiguration: OFF

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -1,9 +1,17 @@
 # See https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html
+
 spring:
   main:
     web-application-type: none
     banner-mode: "off"
   ai:
+    # Right now, we cannot select azure or openai with a single property.
+    # See https://github.com/spring-projects/spring-ai/issues/2712
+    model:
+      embedding:  ${spring.ai.model.chat}
+      audio:
+        transcription:  ${spring.ai.model.chat}
+      image:  ${spring.ai.model.chat}
     openai:
       base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
       api-key: ${OPENAI_API_KEY:enter-your-api-key}
@@ -30,6 +38,12 @@ management.observations.annotations.enabled: true
 logging:
   level:
     root: WARN
+    io:
+      netty:
+        resolver:
+          dns:
+            # Hush warnings about native DNS on MacOS
+            DnsServerAddressStreamProviders: OFF
     org:
       springframework:
         ai:

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -1,5 +1,4 @@
 # See https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html
-
 spring:
   main:
     web-application-type: none


### PR DESCRIPTION
This adds code needed to make 1.0.0-M7 work, which was more tricky than before and tracked upstream in https://github.com/spring-projects/spring-ai/issues/2712 cc @ThomasVitale

Ran with ollama (over openai) and azure

<img width="1898" alt="Screenshot 2025-04-12 at 9 03 30 AM" src="https://github.com/user-attachments/assets/7a5fd2ae-c2c7-445c-957e-3b056965a040" />
<img width="1911" alt="Screenshot 2025-04-12 at 9 08 04 AM" src="https://github.com/user-attachments/assets/4a6eac8c-a013-4fd2-946c-bdd736837c2d" />
