### PR TITLE
genai-function-calling: Adds MCP example to Spring AI

### DIFF
--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -41,10 +41,26 @@ Run maven after setting ENV variables like this:
 ./shdotenv ./mvnw -q clean package exec:exec
 ```
 
+## Run with Model Context Protocol (MCP)
+
+[mcp_server](mcp_server.py) includes code needed to decouple tool discovery and invocation
+via the [Model Context Protocol (MCP) flow][flow-mcp]. To run using MCP, adjust
+the arguments you use for `docker compose run` or `./shdotenv ./mvnw`.
+
+For example, to run with Docker:
+```bash
+docker compose run --build --rm genai-function-calling --mcp
+```
+
+Or to run with Maven:
+```bash
+./shdotenv ./mvnw -q clean package exec:exec -Dtools=mcp
+```
+
 ## Notes
 
 The LLM should generate something like "The latest stable version of
-Elasticsearch is 8.17.4", unless it hallucinates. Just run it again, if you
+Elasticsearch is 8.18.0", unless it hallucinates. Just run it again, if you
 see something else.
 
 Spring AI uses Micrometer which bridges to OpenTelemetry, but needs a few
@@ -80,3 +96,4 @@ OTEL_INSTRUMENTATION_MICROMETER_ENABLED=true
 ---
 [flow]: ../README.md#example-application-flow
 [spring-ai]: https://github.com/spring-projects/spring-ai/
+[flow-mcp]: ../README.md#model-context-protocol-flow

--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -43,9 +43,9 @@ Run maven after setting ENV variables like this:
 
 ## Run with Model Context Protocol (MCP)
 
-[mcp_server](mcp_server.py) includes code needed to decouple tool discovery and invocation
-via the [Model Context Protocol (MCP) flow][flow-mcp]. To run using MCP, adjust
-the arguments you use for `docker compose run` or `./shdotenv ./mvnw`.
+[Mcp.java](src/main/java/example/Mcp.java) includes code needed to decouple
+tool invocation via the [Model Context Protocol (MCP) flow][flow-mcp]. To run
+using MCP, adjust arguments to `docker compose run` or `./shdotenv ./mvnw`.
 
 For example, to run with Docker:
 ```bash

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-ai.version>1.0.0-M7</spring-ai.version>
+        <tools/>
     </properties>
     <dependencies>
         <dependency>
@@ -29,6 +30,14 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -110,6 +119,7 @@
                              also adding the project build directory -->
                         <classpath/>
                         <argument>example.Main</argument>
+                        <argument>--${tools}</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/genai-function-calling/spring-ai/src/main/java/example/ElasticsearchTools.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/ElasticsearchTools.java
@@ -1,15 +1,14 @@
 package example;
 
-import java.util.Comparator;
-import java.util.List;
-
+import jakarta.annotation.Nullable;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import jakarta.annotation.Nullable;
+import java.util.Comparator;
+import java.util.List;
 
 
 @Component
@@ -33,11 +32,11 @@ class ElasticsearchTools {
                 // Filter out non-release versions (e.g. -rc1) and remove " GA" suffix
                 .map(release -> release.version().replace(" GA", ""))
                 .filter(version -> !version.contains("-"))
-                .filter(version ->  {
-                        if (majorVersion == null) {
-                                return true;
-                        }
-                        return version.startsWith(majorVersion + ".");
+                .filter(version -> {
+                    if (majorVersion == null) {
+                        return true;
+                    }
+                    return version.startsWith(majorVersion + ".");
                 })
                 // "8.9.1" > "8.10.0", so coerce to an integer: 80901 < 81000
                 .max(Comparator.comparingInt(v -> {

--- a/genai-function-calling/spring-ai/src/main/java/example/Mcp.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Mcp.java
@@ -1,0 +1,123 @@
+package example;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import org.springframework.ai.mcp.client.autoconfigure.properties.McpStdioClientProperties;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Launches {@linkplain McpServer} in a subprocess and runs
+ * {@linkplain VersionAgent} with its tools via MCP stdio client.
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(VersionAgent.class)
+class McpClientAgent {
+    // Use javaagent instead of spring for configuring OpenTelemetry
+    @Bean
+    OpenTelemetry openTelemetry() {
+        return GlobalOpenTelemetry.get();
+    }
+
+    /**
+     * Generates MCP server configuration in <a href="https://modelcontextprotocol.io/quickstart/user">Claude Desktop Format</a>.
+     * <p/>
+     * Notably, this takes the existing process command, args, and env, and
+     * appends "--mcp-server" to the args. Since this process was launched via
+     * {@linkplain Main#main(String[])}, the additional arg will route the MCP
+     * server subprocess correctly to {@linkplain McpServer}.
+     */
+    String mcpServersConfiguration() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode root = mapper.createObjectNode();
+        ObjectNode serverConfig = mapper.createObjectNode();
+
+        // Set up the configuration structure
+        root.set("mcpServers", mapper.createObjectNode().set("elasticsearch-versions", serverConfig));
+
+        // Get process information
+        ProcessHandle.Info info = ProcessHandle.current().info();
+
+        // Add command
+        serverConfig.put("command",
+                info.command().orElseThrow(() -> new IllegalStateException("Cannot get command of current process")));
+
+        // Add arguments with "--mcp-server" appended
+        ArrayNode argsNode = mapper.createArrayNode();
+        String[] args = info.arguments().orElseThrow(() -> new IllegalStateException("Cannot get arguments of current process"));
+        for (String arg : args) {
+            argsNode.add(arg);
+        }
+        argsNode.add("--mcp-server");
+        serverConfig.set("args", argsNode);
+
+        // Add environment variables
+        serverConfig.set("env", mapper.valueToTree(System.getenv()));
+
+        // Serialize to pretty-printed JSON
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(root);
+    }
+
+    /**
+     * Overrides {@link McpStdioClientProperties} defined by properties with
+     * dynamic values, notably that derive MCP server launch configuration from
+     * the current process.
+     */
+    @Bean
+    @Primary
+    McpStdioClientProperties stdioClientProperties() throws Exception {
+        String mcpServersConfiguration = mcpServersConfiguration();
+
+        McpStdioClientProperties properties = new McpStdioClientProperties();
+        properties.setServersConfiguration(new ByteArrayResource(mcpServersConfiguration.getBytes(StandardCharsets.UTF_8)));
+        return properties;
+    }
+
+
+    static void main(String[] args) {
+        Main.run(McpClientAgent.class, args,
+                "spring.ai.mcp.client.enabled=true",
+                "spring.ai.mcp.client.toolcallback.enabled=true",
+                "spring.ai.mcp.server.enabled=false"
+        );
+    }
+}
+
+/**
+ * Starts an MCP server and registers {@linkplain ElasticsearchTools},
+ * listening on stdin/stdout.
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(ElasticsearchTools.class)
+class McpServer {
+    // Use javaagent instead of spring for configuring OpenTelemetry
+    @Bean
+    OpenTelemetry openTelemetry() {
+        return GlobalOpenTelemetry.get();
+    }
+
+    @Bean
+    public ToolCallbackProvider elasticsearchToolCallbackProvider(ElasticsearchTools elasticsearchTools) {
+        return MethodToolCallbackProvider.builder().toolObjects(elasticsearchTools).build();
+    }
+
+    static void main(String[] args) {
+        Main.run(McpServer.class, args,
+                "spring.ai.mcp.client.enabled=false",
+                "spring.ai.mcp.server.stdio=true"
+        );
+    }
+}

--- a/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
@@ -1,0 +1,37 @@
+package example;
+
+import io.micrometer.tracing.annotation.NewSpan;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallbackProvider;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+class VersionAgent implements CommandLineRunner {
+
+    private final ChatClient chat;
+    private final ToolCallbackProvider tools;
+
+    VersionAgent(ChatModel chat, ToolCallbackProvider tools) {
+        this.chat = ChatClient.builder(chat).build();
+        this.tools = tools;
+    }
+
+    @Override
+    // Without a root span, we get multiple traces and can't understand the multiple requests being made.
+    // Currently, no automatic root span is created for the CommandLineRunner so we do it ourselves.
+    // https://github.com/spring-projects/spring-ai/issues/1440
+    @NewSpan("version-agent")
+    public void run(String... args) {
+        String answer = chat.prompt()
+                .user("What is the latest version of Elasticsearch 8?")
+                .tools(tools)
+                .options(DefaultToolCallingChatOptions.builder().temperature(0.0).build())
+                .call()
+                .content();
+
+        System.out.println(answer);
+    }
+}

--- a/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
@@ -6,6 +6,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,10 +14,12 @@ class VersionAgent implements CommandLineRunner {
 
     private final ChatClient chat;
     private final ToolCallbackProvider tools;
+    private final ConfigurableApplicationContext context;
 
-    VersionAgent(ChatModel chat, ToolCallbackProvider tools) {
+    VersionAgent(ChatModel chat, ToolCallbackProvider tools, ConfigurableApplicationContext context) {
         this.chat = ChatClient.builder(chat).build();
         this.tools = tools;
+        this.context = context;
     }
 
     @Override
@@ -33,5 +36,6 @@ class VersionAgent implements CommandLineRunner {
                 .content();
 
         System.out.println(answer);
+        context.close(); // See https://github.com/spring-projects/spring-ai/issues/2756
     }
 }


### PR DESCRIPTION
This implements the same flow described in the PR that [adds MCP example to Vercel](https://github.com/elastic/observability-examples/pull/58).

Traces work as expected (broken when MCP [until the protocol is fixed](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/246#issuecomment-2796802224)).

Normal is same as before:
![Screenshot 2025-04-15 at 2 15 25 PM](https://github.com/user-attachments/assets/0c44ace5-1b2b-43cc-bae1-f104a0a928d5)

MCP (`--mcp`) launches a sub-process and while that is traced (as it inherits the agent), the propagation is broken at the moment until spec support is added.
![Screenshot 2025-04-15 at 2 16 32 PM](https://github.com/user-attachments/assets/f3250b00-b84c-442e-813b-3c113125d4f4)
![Screenshot 2025-04-15 at 2 16 42 PM](https://github.com/user-attachments/assets/98dc079f-f9f8-4660-a4dd-deb1dbc36286)
![Screenshot 2025-04-15 at 2 16 22 PM](https://github.com/user-attachments/assets/71109305-3f9f-487f-a50b-eb40bae7d72b)
