### PR TITLE
genai-function-calling: moves to final version of openai-agents MCP

### DIFF
--- a/genai-function-calling/openai-agents/requirements.txt
+++ b/genai-function-calling/openai-agents/requirements.txt
@@ -1,8 +1,8 @@
-openai-agents~=0.0.9
+openai-agents~=0.0.11
 httpx~=0.28.1
 mcp~=1.6.0
 
 elastic-opentelemetry~=1.0.0
-# Use openai-agents instrumentation from OpenInference
-openinference-instrumentation-openai-agents~=0.1.7
-openinference-instrumentation-mcp @ git+https://github.com/anuraaga/openinference.git@mcp-python#subdirectory=python/instrumentation/openinference-instrumentation-mcp
+# Use openai-agents and MCP instrumentation from OpenInference
+openinference-instrumentation-openai-agents~=0.1.8
+openinference-instrumentation-mcp~=1.1.0


### PR DESCRIPTION
without MCP
![Screenshot 2025-04-21 at 3 00 36 PM](https://github.com/user-attachments/assets/48c5e8b7-2421-4520-9511-99ba1257fcf8)

with MCP
![Screenshot 2025-04-21 at 3 48 25 PM](https://github.com/user-attachments/assets/a0cf6538-84f9-4f9f-9b7d-1f680dce04c2)
