### PR TITLE
genai-function-calling: implements MCP flow on semantic-kernel-dotnet

### DIFF
--- a/genai-function-calling/semantic-kernel-dotnet/Dockerfile
+++ b/genai-function-calling/semantic-kernel-dotnet/Dockerfile
@@ -11,7 +11,7 @@ FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-alpine AS app
 WORKDIR /app
 COPY *.csproj ./
 RUN dotnet restore
-COPY . ./
+COPY *.cs ./
 RUN dotnet publish -c Release -p:AssemblyName=app -o out
 
 FROM mcr.microsoft.com/dotnet/runtime:${DOTNET_VERSION}-alpine

--- a/genai-function-calling/semantic-kernel-dotnet/README.md
+++ b/genai-function-calling/semantic-kernel-dotnet/README.md
@@ -19,6 +19,16 @@ An OTLP compatible endpoint should be listening for traces, metrics and logs on
 docker compose run --build --rm genai-function-calling
 ```
 
+## Run with Model Context Protocol (MCP)
+
+[Program.cs](Program.cs) includes code needed to decouple tool discovery and
+invocation via the [Model Context Protocol (MCP) flow][flow-mcp]. To run using
+MCP, append `-- --mcp` flag to your `docker compose run` command.
+
+```bash
+docker compose run --build --rm genai-function-calling --mcp
+```
+
 ## Notes
 
 The LLM should generate something like "The latest stable version of
@@ -33,6 +43,16 @@ SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS_SENSITIVE=true
 OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES="Microsoft.SemanticKernel*"
 ```
 
+The official C# SDK for the Model Context Protocol also includes OpenTelemetry
+instrumentation, enabled when "Experimental.ModelContextProtocol*" is added to
+`OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES`.
+
+Finally, [Program.cs](Program.cs) is manually instrumented to start an activity
+in `Main`. This ensures various instrumentation file under a single trace and
+is enabled when "ElasticsearchVersionAgent" is added to
+`OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES`.
+
 ---
 [flow]: ../README.md#example-application-flow
 [semantic-kernel]: https://github.com/microsoft/semantic-kernel/tree/main/dotnet
+[flow-mcp]: ../README.md#model-context-protocol-flow

--- a/genai-function-calling/semantic-kernel-dotnet/app.csproj
+++ b/genai-function-calling/semantic-kernel-dotnet/app.csproj
@@ -11,9 +11,11 @@
  </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.47.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.47.0" />
+    <PackageReference Include="ModelContextProtocol" Version="0.1.0-preview.11" />
   </ItemGroup>
 
 </Project>

--- a/genai-function-calling/semantic-kernel-dotnet/env.example
+++ b/genai-function-calling/semantic-kernel-dotnet/env.example
@@ -28,7 +28,7 @@ OPENAI_API_KEY=
 # OpenTelemetry configuration for SemanticKernel
 SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS=true
 SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS_SENSITIVE=true
-OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES="Microsoft.SemanticKernel*"
+OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES="ElasticsearchVersionAgent,Microsoft.SemanticKernel*,Experimental.ModelContextProtocol*"
 
 # Default to send logs, traces and metrics to an OpenTelemetry collector,
 # accessible via localhost. For example, Elastic Distribution of OpenTelemetry


### PR DESCRIPTION
This implements the MCP flow with [semantic-kernel dotnet](https://github.com/microsoft/semantic-kernel/tree/main/dotnet) and the [official C# MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk).

To my knowledge the C# MCP SDK is the only one that includes experimental otel support. This means you get a lot more detail than the others. On the flip side, you can see a spurious trace on the MCP server, which is due to tracing activity that precedes a client tool request (notifications/initialized).

---

plain agent trace
<img width="1426" alt="Screenshot 2025-04-28 at 5 48 07 PM" src="https://github.com/user-attachments/assets/a657c380-b98e-4e2c-99d6-9c83b2ac242b" />

traces when run with --mcp
<img width="793" alt="Screenshot 2025-04-28 at 5 49 38 PM" src="https://github.com/user-attachments/assets/7e45c65a-0113-4f88-acc8-1641ec1c8d3b" />

agent-mcp trace
<img width="1438" alt="Screenshot 2025-04-28 at 5 49 57 PM" src="https://github.com/user-attachments/assets/8b4b22dc-b5b2-4ae0-affd-e55b72acff5b" />

mcp-server trace
<img width="1438" alt="Screenshot 2025-04-28 at 5 50 38 PM" src="https://github.com/user-attachments/assets/730aeda7-8310-4a47-9d69-dae3256565c7" />
