### PR TITLE
genai-function-calling: add reasoning extraction to vercel ai

### DIFF
--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -52,7 +52,7 @@ const tools = {get_latest_elasticsearch_version: getLatestElasticsearchVersion};
  */
 async function runAgent(tools) {
     const {text} = await generateText({
-        // If using qwen3, remove the reasoning tags from output. GPT models will not have
+        // If using reasoning models, remove the tags from output. Non-reasoning models will not have
         // such tags making it effectively a no-op.
         model: wrapLanguageModel({
             model: openai(model),

--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -1,6 +1,6 @@
 const {createAzure} = require('@ai-sdk/azure');
 const {createOpenAI} = require('@ai-sdk/openai');
-const {generateText, tool} = require('ai');
+const {extractReasoningMiddleware, generateText, tool, wrapLanguageModel} = require('ai');
 const {z} = require('zod');
 const {mcpClientMain} = require('./mcp');
 
@@ -52,7 +52,12 @@ const tools = {get_latest_elasticsearch_version: getLatestElasticsearchVersion};
  */
 async function runAgent(tools) {
     const {text} = await generateText({
-        model: openai(model),
+        // If using qwen3, remove the reasoning tags from output. GPT models will not have
+        // such tags making it effectively a no-op.
+        model: wrapLanguageModel({
+            model: openai(model),
+            middleware: [extractReasoningMiddleware({ tagName: 'think' })],
+        }),
         messages: [{role: 'user', content: "What is the latest version of Elasticsearch 8?"}],
         temperature: 0,
         tools,

--- a/genai-function-calling/vercel-ai/index.js
+++ b/genai-function-calling/vercel-ai/index.js
@@ -52,8 +52,8 @@ const tools = {get_latest_elasticsearch_version: getLatestElasticsearchVersion};
  */
 async function runAgent(tools) {
     const {text} = await generateText({
-        // If using reasoning models, remove the tags from output. Non-reasoning models will not have
-        // such tags making it effectively a no-op.
+        // If using reasoning models, remove the format rewards from output. Non-reasoning models will not have
+        // them making it effectively a no-op.
         model: wrapLanguageModel({
             model: openai(model),
             middleware: [extractReasoningMiddleware({ tagName: 'think' })],


### PR DESCRIPTION
This starts with the one we already had the code example for. I just added the middleware without anything like `if qwen3` since it seemed fine either way, but let me know if we should be more smart about that.

Before
```
❯ npm run start

> genai-function-calling@1.0.0 start
> node --env-file .env --import @elastic/opentelemetry-node --import ./telemetry.js index.js

<think>
Okay, the user is asking for the latest version of Elasticsearch 8. I need to check if there's a function available to get that information. The provided tool is get_latest_elasticsearch_version, which takes a major version parameter. The user specified 8, so I should call that function with majorVersion 8. The response from the tool was 8.18.0, so I should present that as the answer. Make sure to format it correctly in the response.
</think>

The latest version of Elasticsearch 8 is **8.18.0**.
```

After
```
❯ npm run start

> genai-function-calling@1.0.0 start
> node --env-file .env --import @elastic/opentelemetry-node --import ./telemetry.js index.js



The latest version of Elasticsearch 8 is **8.18.0**.
```