### PR TITLE
genai-function-calling: updates spring-ai to 1.0.0

### DIFF
--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -72,6 +72,15 @@ spring:
         log-prompt: true
         log-completion: true
         include-error-logging: true
+logging:
+  level:
+    org:
+      springframework:
+        ai:
+          chat:
+            observation: DEBUG
+            client:
+              observation: DEBUG
 ```
 
 To delegate OpenTelemetry to EDOT, [Main.java](src/main/java/example/Main.java)

--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -78,9 +78,9 @@ logging:
       springframework:
         ai:
           chat:
-            observation: DEBUG
+            observation: INFO
             client:
-              observation: DEBUG
+              observation: INFO
 ```
 
 To delegate OpenTelemetry to EDOT, [Main.java](src/main/java/example/Main.java)

--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -55,7 +55,7 @@ Or to run with Maven:
 ## Notes
 
 The LLM should generate something like "The latest stable version of
-Elasticsearch is 8.18.0", unless it hallucinates. Just run it again, if you
+Elasticsearch is 8.18.1", unless it hallucinates. Just run it again, if you
 see something else.
 
 Spring AI uses Micrometer which bridges to OpenTelemetry, but needs a few
@@ -69,8 +69,8 @@ spring:
   ai:
     chat:
       observations:
-        include-prompt: true
-        include-completion: true
+        log-prompt: true
+        log-completion: true
         include-error-logging: true
 ```
 

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -15,7 +15,7 @@
     <description>Function Calling with Spring AI</description>
     <properties>
         <java.version>21</java.version>
-        <spring-ai.version>1.0.0-RC1</spring-ai.version>
+        <spring-ai.version>1.0.0</spring-ai.version>
         <tools/>
     </properties>
     <dependencies>

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -15,7 +15,7 @@
     <description>Function Calling with Spring AI</description>
     <properties>
         <java.version>21</java.version>
-        <spring-ai.version>1.0.0-M7</spring-ai.version>
+        <spring-ai.version>1.0.0-RC1</spring-ai.version>
         <tools/>
     </properties>
     <dependencies>

--- a/genai-function-calling/spring-ai/src/main/java/example/Main.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Main.java
@@ -63,6 +63,6 @@ class Main {
 
         new SpringApplicationBuilder(source)
                 .properties(properties)
-                .run(args).close();
+                .run(args);
     }
 }

--- a/genai-function-calling/spring-ai/src/main/java/example/Main.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Main.java
@@ -63,6 +63,6 @@ class Main {
 
         new SpringApplicationBuilder(source)
                 .properties(properties)
-                .run(args);
+                .run(args).close();
     }
 }

--- a/genai-function-calling/spring-ai/src/main/java/example/Mcp.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/Mcp.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import org.springframework.ai.mcp.client.autoconfigure.properties.McpClientCommonProperties;
 import org.springframework.ai.mcp.client.autoconfigure.properties.McpStdioClientProperties;
+import org.springframework.ai.mcp.server.autoconfigure.McpServerProperties;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.boot.SpringBootConfiguration;
@@ -88,9 +90,9 @@ class McpClientAgent {
 
     static void main(String[] args) {
         Main.run(McpClientAgent.class, args,
-                "spring.ai.mcp.client.enabled=true",
-                "spring.ai.mcp.client.toolcallback.enabled=true",
-                "spring.ai.mcp.server.enabled=false"
+                McpClientCommonProperties.CONFIG_PREFIX + ".enabled=true",
+                McpClientCommonProperties.CONFIG_PREFIX + ".toolcallback.enabled=true",
+                McpServerProperties.CONFIG_PREFIX + ".enabled=false"
         );
     }
 }
@@ -116,8 +118,8 @@ class McpServer {
 
     static void main(String[] args) {
         Main.run(McpServer.class, args,
-                "spring.ai.mcp.client.enabled=false",
-                "spring.ai.mcp.server.stdio=true"
+                McpClientCommonProperties.CONFIG_PREFIX + ".enabled=false",
+                McpServerProperties.CONFIG_PREFIX + ".stdio=true"
         );
     }
 }

--- a/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
+++ b/genai-function-calling/spring-ai/src/main/java/example/VersionAgent.java
@@ -30,7 +30,7 @@ class VersionAgent implements CommandLineRunner {
     public void run(String... args) {
         String answer = chat.prompt()
                 .user("What is the latest version of Elasticsearch 8?")
-                .tools(tools)
+                .toolCallbacks(tools)
                 .options(DefaultToolCallingChatOptions.builder().temperature(0.0).build())
                 .call()
                 .content();

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -4,13 +4,16 @@ spring:
     web-application-type: none
     banner-mode: "off"
   ai:
-    # Right now, we cannot select azure or openai with a single property.
-    # See https://github.com/spring-projects/spring-ai/issues/2712
     model:
-      embedding:  ${spring.ai.model.chat}
-      audio:
-        transcription:  ${spring.ai.model.chat}
-      image:  ${spring.ai.model.chat}
+      # Disable all models by default and enable per example to avoid eager autoconfiguration.
+      # https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/model/SpringAIModelProperties.java#L37
+      embedding: none
+      embedding.text: none
+      embedding.multimodal: none
+      image: none
+      audio.transcription: none
+      audio.speech: none
+      moderation: none
     openai:
       base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
       api-key: ${OPENAI_API_KEY:enter-your-api-key}
@@ -28,8 +31,8 @@ spring:
 
     chat:
       observations:
-        include-prompt: true
-        include-completion: true
+        log-prompt: true
+        log-completion: true
         include-error-logging: true
 
 management.observations.annotations.enabled: true

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -40,6 +40,7 @@ management.observations.annotations.enabled: true
 logging:
   level:
     root: WARN
+
     io:
       netty:
         resolver:
@@ -49,6 +50,10 @@ logging:
     org:
       springframework:
         ai:
+          chat:
+            observation: DEBUG
+            client:
+              observation: DEBUG
           model:
             chat:
               observation:

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -51,9 +51,9 @@ logging:
       springframework:
         ai:
           chat:
-            observation: DEBUG
+            observation: INFO
             client:
-              observation: DEBUG
+              observation: INFO
           model:
             chat:
               observation:

--- a/genai-function-calling/spring-ai/src/main/resources/application.yml
+++ b/genai-function-calling/spring-ai/src/main/resources/application.yml
@@ -49,6 +49,8 @@ logging:
             DnsServerAddressStreamProviders: OFF
     org:
       springframework:
+        # Note: Prompt and completion logging is via SLF4J, which cannot set
+        # the OpenTelemetry log attribute "event.name".
         ai:
           chat:
             observation: INFO


### PR DESCRIPTION
<img width="1324" alt="Screenshot 2025-05-24 at 8 39 28 PM" src="https://github.com/user-attachments/assets/d8fa338c-4d58-48a1-96dd-af36e2243e73" />

### Note: MCP propagation is still broke

Below are created, but I don't see any relevant outcomes so far.
* https://github.com/spring-projects/spring-ai/issues/2967
* https://github.com/modelcontextprotocol/java-sdk/issues/225