### PR TITLE
archgw: adds otel-tui prom instructions and updates to pending EDOT

### DIFF
--- a/inference-platforms/archgw/README.md
+++ b/inference-platforms/archgw/README.md
@@ -20,13 +20,24 @@ working Docker configuration. Run `archgw` using `uvx` from [uv][uv].
 uvx archgw up --service archgw --foreground
 ```
 
-## Start Prometheus to Elasticsearch pump
+## Start Prometheus Scraping
+
+### Elastic Stack
 
 If your OpenTelemetry backend is Elasticsearch, you can pump Prometheus metrics
 coming from Arch Gateway to Elasticsearch like this:
 
 ```bash
 docker compose -f docker-compose-elastic.yml run --rm prometheus-pump
+```
+
+### otel-tui
+
+If you are using [otel-tui][otel-tui] to visualize OpenTelemetry data, you can
+add Arch Gateway's Prometheus endpoint to it when starting, like this:
+
+```bash
+otel-tui --prom-target http://localhost:19901/stats?format=prometheus
 ```
 
 ## Call Arch Gateway with python

--- a/inference-platforms/archgw/docker-compose-elastic.yml
+++ b/inference-platforms/archgw/docker-compose-elastic.yml
@@ -48,8 +48,8 @@ configs:
 services:
   # prometheus-pump is an OpenTelemetry Collector that scrapes Prometheus metrics
   prometheus-pump:
-    # TODO: Use EDOT after https://github.com/elastic/elastic-agent/pull/8372
-    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.127.0
+    # TODO: docker.elastic.co/elastic-agent/elastic-otel-collector:9.0.3
+    image: docker.elastic.co/elastic-agent/elastic-otel-collector:9.0.3-SNAPSHOT
     container_name: prometheus-pump
     command: [
       "--config=/etc/otel/config.yaml",


### PR DESCRIPTION
This updates the inference platform example of archgw since otel-tui recently has a scrape config option that works with it.

<img width="1511" alt="Screenshot 2025-06-16 at 11 30 48 AM" src="https://github.com/user-attachments/assets/e5a7f65e-a8fc-4e70-aab0-664044bcf764" />

Elastic already worked, but I updated the yaml to use the pending EDOT collector image. To verify that, I took a much longer path, just to do it.

I used [goose](https://github.com/block/goose) + [elasticsearch MCP server](https://github.com/elastic/mcp-server-elasticsearch) to ask questions about requests in natural language. It was able to figure it out. Setup was just doing `goose configure` and adding an extension with details in the ES MCP server docs.

```bash
$ goose run  -t "tell me about the performance of envoy requests looking at otel metrics in my elasticsearch indices"


starting session | provider: aws_bedrock model: anthropic.claude-3-5-sonnet-20240620-v1:0
    logging to /Users/adriancole/.local/share/goose/sessions/20250616_112639.jsonl
    working directory: /Users/adriancole/oss/otel-tui
Certainly! To analyze the performance of Envoy requests using OpenTelemetry (OTel) metrics stored in your Elasticsearch indices, we'll need to follow a few steps. Let's break this down and use the Elasticsearch tools available to us.

First, let's check what indices are available in your Elasticsearch cluster that might contain OTel metrics for Envoy.
─── list_indices | elasticsearch ──────────────────────────
indexPattern: *otel*
--snip--

3. Performance Metrics:
   - For the `egress_traffic_llm` service, we see request transactions with the following metrics:
     - Total transactions: 4
     - Total duration sum: 4,142,977 (units not specified, likely microseconds or nanoseconds)
     - Average duration per transaction: 1,035,744 (4,142,977 / 4)
--snip---

```

Here's the full output of goose while it tried to figure out things. A good agent prompt file, or even a specialized EDOT MCP server would reduce a lot of the bumbling and improve perf.

<details>

```bash
$ goose run  -t "tell me about the performance of envoy requests looking at otel metrics in my elasticsearch indices"


starting session | provider: aws_bedrock model: anthropic.claude-3-5-sonnet-20240620-v1:0
    logging to /Users/adriancole/.local/share/goose/sessions/20250616_112639.jsonl
    working directory: /Users/adriancole/oss/otel-tui
Certainly! To analyze the performance of Envoy requests using OpenTelemetry (OTel) metrics stored in your Elasticsearch indices, we'll need to follow a few steps. Let's break this down and use the Elasticsearch tools available to us.

First, let's check what indices are available in your Elasticsearch cluster that might contain OTel metrics for Envoy.
─── list_indices | elasticsearch ──────────────────────────
indexPattern: *otel*



Great! We can see several OpenTelemetry-related indices. For Envoy metrics, we'll likely want to focus on the transaction and service-related indices. Let's start by examining the mappings of the `metrics-transaction.1m.otel-default` index to see what fields are available:
─── get_mappings | elasticsearch ──────────────────────────
index: ...



Based on the mappings, we can see that this index contains transaction-related metrics. Now, let's query this index to get some insights into the performance of Envoy requests. We'll focus on the transaction duration, which is typically a good indicator of performance.

Here's a query to get the average transaction duration for Envoy requests over the last hour:
─── search | elasticsearch ──────────────────────────
index: ...
queryBody:
    aggs:
        avg_duration:
            avg:
                field: metrics.transaction.duration.summary.sum
        total_transactions:
            sum:
                field: ...
    query:
        bool:
            must:
                - 
                    range:
                        @timestamp:
                            gte: now-1h
                            lte: now
                - 
                    term:
                        attributes.transaction.type: request
    size: 0



I apologize for the confusion. It seems that the query didn't return any results for the specified time range. Let's try a broader time range and see if we can get some data:
─── search | elasticsearch ──────────────────────────
index: ...
queryBody:
    aggs:
        avg_duration:
            avg:
                field: metrics.transaction.duration.summary.sum
        total_transactions:
            sum:
                field: ...
    query:
        bool:
            must:
                - 
                    range:
                        @timestamp:
                            gte: now-24h
                            lte: now
                - 
                    term:
                        attributes.transaction.type: request
    size: 0



I apologize once again. It seems that we're not getting any results even with a broader time range. Let's try to investigate what kind of data is actually present in the index. We'll query for a small sample of documents without any filters to see what we're working with:
─── search | elasticsearch ──────────────────────────
index: ...
queryBody:
    _source:
        - 
            @timestamp
        - 
            attributes.transaction.type
        - 
            metrics.transaction.duration.summary
        - 
            resource.attributes.service.name
    query:
        match_all:
    size: 5



Thank you for your patience. Now we can see some data in the index. It looks like we have transactions from two services: "archgw" and "egress_traffic_llm". Let's analyze the performance of Envoy requests based on this data.

Here's an updated query to get insights into the performance of Envoy requests:
─── search | elasticsearch ──────────────────────────
index: ...
queryBody:
    aggs:
        services:
            aggs:
                avg_duration:
                    avg:
                        field: metrics.transaction.duration.summary.sum
                total_transactions:
                    sum:
                        field: ...
            terms:
                field: resource.attributes.service.name
                size: 10
    query:
        bool:
            must:
                - 
                    range:
                        @timestamp:
                            gte: now-15m
                - 
                    term:
                        attributes.transaction.type: request
    size: 0



Based on the results, here's an analysis of the performance of Envoy requests looking at OpenTelemetry metrics in your Elasticsearch indices:

1. Services: We have identified two services in the data:
   - `archgw`
   - `egress_traffic_llm`

2. Transaction Types: We see two types of transactions:
   - `unknown`
   - `request`

3. Performance Metrics:
   - For the `egress_traffic_llm` service, we see request transactions with the following metrics:
     - Total transactions: 4
     - Total duration sum: 4,142,977 (units not specified, likely microseconds or nanoseconds)
     - Average duration per transaction: 1,035,744 (4,142,977 / 4)

4. Timeframe: The data we're seeing is very recent, with timestamps around 2025-06-16T03:24:XX, which is just a few minutes before the current time.

5. Limited Data: It's worth noting that we have a limited amount of data to work with, which may not provide a comprehensive view of the system's performance over time.

Insights and Recommendations:

1. Recent Data: The data we're seeing is very recent, which is good for real-time monitoring but may not provide historical context.

2. Request Duration: For the `egress_traffic_llm` service, the average request duration is about 1,035,744 units (likely microseconds or nanoseconds). Without historical data or established baselines, it's hard to say if this is good or bad performance. However, if we assume microseconds, this would be about 1.04 seconds per request, which might be considered slow for many types of services.

3. Transaction Types: Many transactions are labeled as "unknown" type. It would be beneficial to investigate why these transactions are not being properly categorized. This could be due to misconfiguration in the OpenTelemetry instrumentation.

4. Service Differentiation: We see transactions from two different services. It would be useful to gather more data to compare their performance and understand their roles in the system.

5. Monitoring Improvements:
   - Set up alerts for when average request duration exceeds certain thresholds.
   - Implement more detailed transaction labeling to better understand different types of requests.
   - Consider adding more dimensions to your metrics, such as HTTP status codes, to get a more comprehensive view of service health.

6. Data Volume: The amount of data seems relatively low. You might want to check if all expected services are properly instrumented and sending metrics to Elasticsearch.

7. Further Investigation:
   - Look into why some transactions are typed as "unknown" and see if you can improve the instrumentation to properly categorize these.
   - Gather more historical data to establish performance baselines and trends.
   - Investigate the role of the `archgw` service and why it doesn't have any "request" type transactions in this sample.

To get a more comprehensive view of your Envoy requests' performance, you would need to gather data over a longer period and potentially add more detailed metrics. This would allow for trend analysis and more accurate performance assessments.
```

</details>
