### PR TITLE
spring-ai: bumps to latest

### DIFF
--- a/genai-function-calling/spring-ai/README.md
+++ b/genai-function-calling/spring-ai/README.md
@@ -55,7 +55,7 @@ Or to run with Maven:
 ## Notes
 
 The LLM should generate something like "The latest stable version of
-Elasticsearch is 8.18.1", unless it hallucinates. Just run it again, if you
+Elasticsearch is 8.19.3", unless it hallucinates. Just run it again, if you
 see something else.
 
 Spring AI uses Micrometer which bridges to OpenTelemetry, but needs a few

--- a/genai-function-calling/spring-ai/pom.xml
+++ b/genai-function-calling/spring-ai/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>co.elastic.observability-labs</groupId>
@@ -15,7 +15,7 @@
     <description>Function Calling with Spring AI</description>
     <properties>
         <java.version>21</java.version>
-        <spring-ai.version>1.0.0</spring-ai.version>
+        <spring-ai.version>1.0.1</spring-ai.version>
         <tools/>
     </properties>
     <dependencies>
@@ -50,8 +50,8 @@
         <dependency>
             <groupId>co.elastic.otel</groupId>
             <artifactId>elastic-otel-javaagent</artifactId>
-            <version>1.4.1</version>
-            <scope>optional</scope>
+            <version>1.5.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
mcp isn't happy

```bash
$ docker compose run --build --rm genai-function-calling --mcp                                                                                
--snip--
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended                                      
2025-09-08 04:01:01,996 [main] INFO  io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.5.0
2025-09-08T04:01:04.496Z ERROR 1 --- [ool-12-thread-1] [                                                 ] i.m.c.transport.StdioClientTransport     : Error processing inbound message for line: 2025-09-08 04:01:04,489 [main] INFO  io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.5.0

com.fasterxml.jackson.core.JsonParseException: Unexpected character ('-' (code 45)): Expected space separating root-level values
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
        at com.fasterxml.jackson.core.JsonParser._constructReadException(JsonParser.java:2672) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:742) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportMissingRootWS(ParserMinimalBase.java:660) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._verifyRootSpace(ReaderBasedJsonParser.java:1800) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._parseUnsignedNumber(ReaderBasedJsonParser.java:1396) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:777) ~[jackson-core-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:5058) ~[jackson-databind-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4961) ~[jackson-databind-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3887) ~[jackson-databind-2.19.2.jar!/:2.19.2]
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3870) ~[jackson-databind-2.19.2.jar!/:2.19.2]
        at io.modelcontextprotocol.spec.McpSchema.deserializeJsonRpcMessage(McpSchema.java:157) ~[mcp-0.10.0.jar!/:0.10.0]
        at io.modelcontextprotocol.client.transport.StdioClientTransport.lambda$startInboundProcessing$6(StdioClientTransport.java:260) ~[mcp-0.10.0.jar!/:na]
        at io.opentelemetry.javaagent.shaded.instrumentation.reactor.v3_1.ContextPropagationOperator$RunnableWrapper.run(ContextPropagationOperator.java:373) ~[elastic-otel-javaagent.jar:na]
        at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68) ~[reactor-core-3.7.9.jar!/:3.7.9]
        at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28) ~[reactor-core-3.7.9.jar!/:3.7.9]
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
        at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]

q^C2025-09-08T04:01:20.272Z  WARN 1 --- [           main] [                                                 ] s.c.a.AnnotationConfigApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'example.VersionAgent': Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'openAiChatModel' defined in class path resource [org/springframework/ai/model/openai/autoconfigure/OpenAiChatAutoConfiguration.class]: Unsatisfied dependency expressed through method 'openAiChatModel' parameter 4: Error creating bean with name 'toolCallingManager' defined in class path resource [org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.class]: Unsatisfied dependency expressed through method 'toolCallingManager' parameter 0: Error creating bean with name 'toolCallbackResolver' defined in class path resource [org/springframework/ai/model/tool/autoconfigure/ToolCallingAutoConfiguration.class]: Unsatisfied dependency expressed through method 'toolCallbackResolver' parameter 2: Error creating bean with name 'mcpToolCallbacks' defined in class path resource [org/springframework/ai/mcp/client/autoconfigure/McpToolCallbackAutoConfiguration.class]: Failed to instantiate [org.springframework.ai.mcp.SyncMcpToolCallbackProvider]: Factory method 'mcpToolCallbacks' threw exception with message: Error creating bean with name 'mcpSyncClients' defined in class path resource [org/springframework/ai/mcp/client/autoconfigure/McpClientAutoConfiguration.class]: Failed to instantiate [java.util.List]: Factory method 'mcpSyncClients' threw exception with message: java.lang.InterruptedException


```