### PR TITLE
archgw: address drift in prometheus cluster name

### DIFF
--- a/inference-platforms/archgw/README.md
+++ b/inference-platforms/archgw/README.md
@@ -64,10 +64,11 @@ and anything added in Arch Gateway's [wasm filter][archgw-wasm].
   instructions to run from Docker (to avoid nested docker).
 * Traces come from Envoy, whose configuration is written by `archgw`. At the
   moment, this hard-codes aspects including default ports.
-* Prometheus metrics show the cluster as "openai_host" - the provider_interface
+* Prometheus metrics show the cluster as "ollama_host" - the provider_interface
   plus the first segment of the hostname (dots truncate the rest). The "host"
   comes from "host.docker.internal".
 * Until [this][openai-responses] resolves, don't use `--use-responses-api`.
+* Until [this][docker-env] resolves, make sure your PATH has /usr/local/bin.
 
 The chat prompt was designed to be idempotent, but the results are not. You may
 see something besides 'South Atlantic Ocean.'.
@@ -81,3 +82,4 @@ Just run it again until we find a way to make the results idempotent.
 [uv]: https://docs.astral.sh/uv/getting-started/installation/
 [openai-responses]: https://github.com/katanemo/archgw/issues/476
 [otel-tui]: https://github.com/ymtdzzz/otel-tui
+[docker-env]: https://github.com/katanemo/archgw/issues/573

--- a/inference-platforms/archgw/arch_config.yaml
+++ b/inference-platforms/archgw/arch_config.yaml
@@ -8,10 +8,9 @@ listeners:
     timeout: 30s
 
 llm_providers:
-  # ollama/ in the model name forces using the ollama interface even though we
-  # want provider_interface: openai. local/ avoids this.
-  - model: local/qwen3:0.6b
-    provider_interface: openai
+  # Use ollama directly, since we can't inherit OPENAI_BASE_URL etc and need
+  # to hard-code the model anyway.
+  - model: ollama/qwen3:0.6b
     # This configuration is converted to Envoy and run inside Docker.
     base_url: http://host.docker.internal:11434
     default: true

--- a/inference-platforms/archgw/docker-compose-elastic.yml
+++ b/inference-platforms/archgw/docker-compose-elastic.yml
@@ -2,7 +2,7 @@ configs:
   # Configuration is simplified from archgw here:
   # https://github.com/katanemo/archgw/blob/main/docs/source/guides/observability/monitoring.rst
   #
-  # Note: The cluster name for openai + host.docker.internal = openai_host
+  # Note: The cluster name for ollama + host.docker.internal = ollama_host
   prometheus-pump-config:
     content: |
       receivers:


### PR DESCRIPTION
Recent changes made some config incompatible and fixed the model name metrics glitch by no longer recording the model name.

<img width="1524" height="279" alt="Screenshot 2025-09-24 at 1 05 21 PM" src="https://github.com/user-attachments/assets/7692ff05-3c70-4882-b8a6-9ddc0b107be8" />


```bash
$ curl -sl http://localhost:19901/stats?format=prometheus|grep ollama|grep -v ' 0' |tail -2
envoy_cluster_docker_internal_upstream_rq_time_sum{envoy_cluster_name="ollama_host"} 1455
envoy_cluster_docker_internal_upstream_rq_time_count{envoy_cluster_name="ollama_host"} 2
```
